### PR TITLE
workflows: Enable lfs in gh-pages

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -222,6 +222,7 @@ jobs:
         uses: actions/checkout@v3
         if: always()
         with:
+          lfs: true
           ref: gh-pages
           path: gh-pages
 


### PR DESCRIPTION
Sometimes the logs can be large.
For example:
  remote: error: File 224/data/attachments/305b606753ef6ea8.zip is 213.16 MB;
this exceeds GitHub's file size limit of 100.00 MB
  remote: error: GH001: Large files detected. You may want to try
Git Large File Storage - https://git-lfs.github.com.

This will help save the report and analyze it.